### PR TITLE
use `advice-add` instead of creating a bind + Add support for default face for custom cookies +  Add support for org-ctrl-c-ctrl-c shortcut.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,21 @@ It's recommended to play around with which one works best for your workflow (I p
 
 ### Keybindings and Hooks
 
-The `use-package` configuration below will bind `C-c #` in the `org-mode-map` (which originally would call `org-update-statistics-cookies`) to a function that will call both `(org-update-statistics-cookies all)` and `org-custom-cookies-update-containing-subtree`. It will also add hooks that will be run when you clock out, as well as when the "Effort" property is updated.
+The `use-package` configuration below will `advise`
+`org-update-statistics-cookies` to run
+`org-custom-cookies-update-containing-subtree`, which will make it
+also update the custom cookies whenever an inbuilt cookie is updated,
+this means `C-c #` will also work with the custom cookies. It will
+also add hooks that will be run when you clock out, as well as when
+the "Effort" property is updated.
 
 ```elisp
 (use-package org-custom-cookies
   :ensure t
   :after org
-  :bind (:map org-mode-map
-              ("C-c #" . (lambda (all) (interactive "P")
-                           (progn (org-update-statistics-cookies all)
-                                  (org-custom-cookies-update-containing-subtree)))))
   :config
+  (advice-add 'org-update-statistics-cookies :after 
+	  'org-custom-cookies-update-containing-subtree)
   (add-hook 'org-clock-out-hook 'org-custom-cookies-update-containing-subtree)
   (add-hook 'org-property-changed-functions
             (lambda(name value)

--- a/org-custom-cookies.el
+++ b/org-custom-cookies.el
@@ -162,12 +162,15 @@ top-level heading."
   (cl-loop for (regex . callback) in org-custom-cookies-alist
            do (org-custom-cookies--update-current-heading-cookie regex callback)))
 
-(defun org-custom-cookies--enable-cookie-face-for-all-custom-cookies ()
-  "Make sure all custom cookies look like the default cookies."
+(defun org-custom-cookies--cookie-face-for-all-custom-cookies ()
+  "Apply org cookie face on custom-org-cookies.
+
+Hook this function to `org-font-lock-set-keywords-hook' for it work."
   (cl-loop for (regex . callback) in org-custom-cookies-alist
-	   do (font-lock-add-keywords
-	       'org-mode
-	       `((,regex . 'org-checkbox-statistics-todo)))))
+	   do (setq org-font-lock-extra-keywords
+		    (append org-font-lock-extra-keywords
+			    `((,regex (0 'org-checkbox-statistics-todo prepend)))))))
+
 
 (defun org-custom-cookies--update-cookie-ctrl-c-ctrl-c ()
 "Update the custom cookie under the cursor using `org-ctrl-c-ctrl-c'.

--- a/org-custom-cookies.el
+++ b/org-custom-cookies.el
@@ -169,6 +169,19 @@ top-level heading."
 	       'org-mode
 	       `((,regex . 'org-checkbox-statistics-todo)))))
 
+(defun org-custom-cookies--update-cookie-ctrl-c-ctrl-c ()
+"Update the custom cookie under the cursor using `org-ctrl-c-ctrl-c'.
+This will update any org custom cookie in the fashion as with default
+org cookies.
+
+Hook this function to `org-ctrl-c-ctrl-c-hook' for it to work."
+  (catch 'updated-cookie
+    (cl-loop for (regex . callback) in org-custom-cookies-alist
+             do (if (org-in-regexp regex)
+                    (progn
+                      (org-custom-cookies--update-nearest-heading-cookie regex callback)
+                      (throw 'updated-cookie 1))))))
+
 ;;;###autoload
 (defun org-custom-cookies-update-nearest-heading (&optional all)
   "Update all custom cookies for the nearest parent heading containing the cookie.

--- a/org-custom-cookies.el
+++ b/org-custom-cookies.el
@@ -162,6 +162,13 @@ top-level heading."
   (cl-loop for (regex . callback) in org-custom-cookies-alist
            do (org-custom-cookies--update-current-heading-cookie regex callback)))
 
+(defun org-custom-cookies--enable-cookie-face-for-all-custom-cookies ()
+  "Make sure all custom cookies look like the default cookies."
+  (cl-loop for (regex . callback) in org-custom-cookies-alist
+	   do (font-lock-add-keywords
+	       'org-mode
+	       `((,regex . 'org-checkbox-statistics-todo)))))
+
 ;;;###autoload
 (defun org-custom-cookies-update-nearest-heading (&optional all)
   "Update all custom cookies for the nearest parent heading containing the cookie.


### PR DESCRIPTION
This change allows people to use the bindings they may have created for updating the cookies in a simpler fashion. It also facilitates `C-c C-c` action on the cookies (Does not work on custom cookies but updates the custom cookies when done on a built in cookie).