### PR TITLE
feat: add support for `org-ctrl-c-ctrl-c'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ There are five different functions that can be used for updating custom cookies:
 - `org-custom-cookies-update-subtree`: Updates any custom cookies found in the current heading and any child heading of the current heading
 - `org-custom-cookies-update-containing-subtree`: First finds the topmost parent heading that contains a custom cookie, and then updates all custom cookies in headings in that subtree. This is similar to `org-custom-cookies-update-nearest-heading`, except instead of stopping after finding the custom cookie, it 
 - `org-custom-cookies-update-all`: Updates all custom cookies in the buffer
+- `org-custom-cookies--update-cookie-ctrl-c-ctrl-c`: Updates cookies under cursor when for keybinding `C-c C-c`.
 
 It's recommended to play around with which one works best for your workflow (I personally prefer `org-custom-cookies-update-containing-subtree`), and bind this to a key. For convenience, using a prefix argument (`C-u`) with any of these will run `org-custom-cookies-update-all`.
 
 ### Keybindings and Hooks
 
-The `use-package` configuration below will bind `C-c #` in the `org-mode-map` (which originally would call `org-update-statistics-cookies`) to a function that will call both `(org-update-statistics-cookies all)` and `org-custom-cookies-update-containing-subtree`. It will also add hooks that will be run when you clock out, as well as when the "Effort" property is updated.
+The `use-package` configuration below will bind `C-c #` in the `org-mode-map` (which originally would call `org-update-statistics-cookies`) to a function that will call both `(org-update-statistics-cookies all)` and `org-custom-cookies-update-containing-subtree`. It will also add hooks that will be run when you clock out, as well as when the "Effort" property is updated. It also enables `C-c C-c` for the custom cookies.
 
 ```elisp
 (use-package org-custom-cookies
@@ -74,6 +75,7 @@ The `use-package` configuration below will bind `C-c #` in the `org-mode-map` (w
                            (progn (org-update-statistics-cookies all)
                                   (org-custom-cookies-update-containing-subtree)))))
   :config
+  (add-hook 'org-ctrl-c-ctrl-c-hook 'org-custom-cookies--update-cookie-ctrl-c-ctrl-c)
   (add-hook 'org-clock-out-hook 'org-custom-cookies-update-containing-subtree)
   (add-hook 'org-property-changed-functions
             (lambda(name value)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It's recommended to play around with which one works best for your workflow (I p
 
 ### Keybindings and Hooks
 
-The `use-package` configuration below will `advise` `org-update-statistics-cookies` to run `org-custom-cookies-update-containing-subtree`, which will result in custom cookies being updated whenever built-in statistics cookie are updated, meaning that `C-c #` will also work with the custom cookies. It then enables `C-c C-c` for updating custom cookies. Finally, adds hooks that will be run when you clock out, as well as when the "Effort" property is updated.
+The `use-package` configuration below will `advise` `org-update-statistics-cookies` to run `org-custom-cookies-update-containing-subtree`, which will result in custom cookies being updated whenever built-in statistics cookie are updated, meaning that `C-c #` will also work with the custom cookies. It then enables `C-c C-c` for updating custom cookies. Finally, it adds hooks that will be run when you clock out, as well as when the "Effort" property is updated.
 
 ```elisp
 (use-package org-custom-cookies

--- a/org-custom-cookies.el
+++ b/org-custom-cookies.el
@@ -162,6 +162,19 @@ top-level heading."
   (cl-loop for (regex . callback) in org-custom-cookies-alist
            do (org-custom-cookies--update-current-heading-cookie regex callback)))
 
+(defun org-custom-cookies--update-cookie-ctrl-c-ctrl-c ()
+"Update the custom cookie under the cursor using `org-ctrl-c-ctrl-c'.
+This will update any org custom cookie in the fashion as with default
+org cookies.
+
+Hook this function to `org-ctrl-c-ctrl-c-hook' for it to work."
+  (catch 'updated-cookie
+    (cl-loop for (regex . callback) in org-custom-cookies-alist
+             do (if (org-in-regexp regex)
+                    (progn
+                      (org-custom-cookies--update-nearest-heading-cookie regex callback)
+                      (throw 'updated-cookie 1))))))
+
 ;;;###autoload
 (defun org-custom-cookies-update-nearest-heading (&optional all)
   "Update all custom cookies for the nearest parent heading containing the cookie.

--- a/org-custom-cookies.el
+++ b/org-custom-cookies.el
@@ -168,12 +168,11 @@ This will update any org custom cookie in the fashion as with default
 org cookies.
 
 Hook this function to `org-ctrl-c-ctrl-c-hook' for it to work."
-  (catch 'updated-cookie
     (cl-loop for (regex . callback) in org-custom-cookies-alist
              do (if (org-in-regexp regex)
                     (progn
                       (org-custom-cookies--update-nearest-heading-cookie regex callback)
-                      (throw 'updated-cookie 1))))))
+                      (cl-return 'updated-cookie)))))
 
 ;;;###autoload
 (defun org-custom-cookies-update-nearest-heading (&optional all)

--- a/org-custom-cookies.el
+++ b/org-custom-cookies.el
@@ -163,9 +163,7 @@ top-level heading."
            do (org-custom-cookies--update-current-heading-cookie regex callback)))
 
 (defun org-custom-cookies--update-cookie-ctrl-c-ctrl-c ()
-"Update the custom cookie under the cursor using `org-ctrl-c-ctrl-c'.
-This will update any org custom cookie in the fashion as with default
-org cookies.
+  "Update the custom cookie under the cursor using `org-ctrl-c-ctrl-c'.
 
 Hook this function to `org-ctrl-c-ctrl-c-hook' for it to work."
     (cl-loop for (regex . callback) in org-custom-cookies-alist


### PR DESCRIPTION
This will allow users to use `C-c C-c` while keeping their cursor on the cookie they want to update, to update it.